### PR TITLE
fix dateToNumber

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -10,7 +10,7 @@ export const todayDate = new Date();
 export const day1Date = new Date(2022, 3, 1, todayDate.getHours(), todayDate.getMinutes(), todayDate.getSeconds(), todayDate.getMilliseconds());
 
 export function dateToNumber(date: Date) : number {
-  return Math.floor((date.getTime() - day1Date.getTime())/(1000*60*60*24));
+  return Math.round((date.getTime() - day1Date.getTime())/(1000*60*60*24));
 }
 
 const todayNumber = dateToNumber(todayDate);


### PR DESCRIPTION
Found this issue while in Morrocoo.

The issue comes from the fact that the timezone in Morrocoo today is one hour ahead of the timezone there on the first day you calculate from, so the floor discounts the approx 23/24 in days calculation and ends up showing the previous puzzle

